### PR TITLE
Add height tag for withdraw transactions

### DIFF
--- a/abci/handlers/withdraw/withdraw.go
+++ b/abci/handlers/withdraw/withdraw.go
@@ -3,6 +3,7 @@ package withdraw
 import (
 	"math/big"
 	"reflect"
+	"strconv"
 
 	"github.com/likecoin/likechain/abci/account"
 	"github.com/likecoin/likechain/abci/context"
@@ -118,7 +119,10 @@ func deliverWithdraw(state context.IMutableState, rawTx *types.Transaction, txHa
 
 	return response.Success.Merge(response.R{
 		Tags: []common.KVPair{
-			{[]byte("tx.withdraw"), nil},
+			{
+				Key:   []byte("withdraw.height"),
+				Value: []byte(strconv.FormatInt(state.GetHeight()+1, 10)),
+			},
 		},
 		Data: packedTx,
 	})


### PR DESCRIPTION
The tag is used by service which commit AppHash onto Relay contract, for searching withdraw transactions within a range of block height quickly